### PR TITLE
Updated copybutton.js to work in recent Sphinx versions

### DIFF
--- a/_theme/scipy/static/js/copybutton.js
+++ b/_theme/scipy/static/js/copybutton.js
@@ -6,6 +6,7 @@ $(document).ready(function() {
      * the >>> and ... prompts and the output and thus make the code
      * copyable. */
     var div = $('.highlight-python .highlight,' +
+                '.highlight-default .highlight,' +
                 '.highlight-python3 .highlight')
     var pre = div.find('pre');
 
@@ -31,6 +32,7 @@ $(document).ready(function() {
             var button = $('<span class="copybutton">&gt;&gt;&gt;</span>');
             button.css(button_styles)
             button.attr('title', hide_text);
+            button.data('hidden', 'false');
             jthis.prepend(button);
         }
         // tracebacks (.gt) contain bare text elements that need to be
@@ -41,20 +43,24 @@ $(document).ready(function() {
     });
 
     // define the behavior of the button when it's clicked
-    $('.copybutton').toggle(
-        function() {
-            var button = $(this);
+    $('.copybutton').click(function(e){
+        e.preventDefault();
+        var button = $(this);
+        if (button.data('hidden') === 'false') {
+            // hide the code output
             button.parent().find('.go, .gp, .gt').hide();
             button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'hidden');
             button.css('text-decoration', 'line-through');
             button.attr('title', show_text);
-        },
-        function() {
-            var button = $(this);
+            button.data('hidden', 'true');
+        } else {
+            // show the code output
             button.parent().find('.go, .gp, .gt').show();
             button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'visible');
             button.css('text-decoration', 'none');
             button.attr('title', hide_text);
-        });
+            button.data('hidden', 'false');
+        }
+    });
 });
 


### PR DESCRIPTION
Hello,

I have a proposed fix for [SciPy issue # 7369](https://github.com/scipy/scipy/issues/7369). It is fairly straightforward, and now that I figured out a solution a search reveals the solution is already replicated across [thousands of projects on GitHub](https://github.com/search?q=%27.highlight-default+.highlight%2C%27+copybutton&type=Code&utf8=%E2%9C%93). 

I bisected the different Sphinx versions until discovering that 1.4.0 was the version this problem appeared in; the last version this used to work in was 1.3.7. I'm not sure what the exact change in Sphinx is, but I was able to come up with this solution looking at the diff of the produced source code of the two versions.

This also hasn't made its way [into CPython](https://github.com/python/cpython/blob/master/Doc/tools/static/copybutton.js), so I should probably submit the patch there too.

Sincerely,
Caleb