### PR TITLE
fix so 'script()' call works

### DIFF
--- a/_theme/scipy/layout.html
+++ b/_theme/scipy/layout.html
@@ -121,7 +121,9 @@
     {%- endblock %}
     {{ css() }}
     {%- if not embedded %}
+    {%- block scripts %}
     {{ script() }}
+    {%- endblock %}
     {%- if use_opensearch %}
     <link rel="search" type="application/opensearchdescription+xml"
           title="{% trans docstitle=docstitle|e %}Search within {{ docstitle }}{% endtrans %}"


### PR DESCRIPTION
Fixes #9 by allowing the `scripts()` call to actually run. Search was still broken on [devdocs](http://www.numpy.org/devdocs/search.html), this seems to fix it. 

At some point we should update the theme by replaying these changes to the basic theme on top of a more modern version.