### PR TITLE
MAINT: Add CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,65 @@
+version: 2
+jobs:
+  build_docs:
+    docker:
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      - image: circleci/python:3.7.0
+
+    working_directory: ~/scipy-sphinx-theme
+
+    steps:
+      - checkout
+
+      - run:
+          name: clone and configure SciPy repo
+          command: |
+            git clone https://github.com/scipy/scipy.git ~/repo
+
+      - run:
+          name: update submodules
+          command: |
+            cd ~/repo
+            git submodule init
+            git submodule update
+
+      - run:
+          name: install Debian dependencies
+          command: |
+            sudo apt-get update
+            sudo apt-get install libatlas-dev libatlas-base-dev liblapack-dev gfortran libgmp-dev libmpfr-dev libfreetype6-dev libpng-dev zlib1g zlib1g-dev texlive-fonts-recommended texlive-latex-recommended texlive-latex-extra texlive-generic-extra latexmk texlive-xetex fonts-freefont-otf
+
+      - run:
+          name: setup Python venv
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install --install-option="--no-cython-compile" cython
+            pip install numpy
+            pip install nose mpmath argparse Pillow codecov matplotlib Sphinx
+            pip install pybind11
+
+      - run:
+          name: override scipy-sphinx-theme in repo
+          command: |
+            cd ~/repo/doc
+            rm -Rf scipy-sphinx-theme
+            ln -s ~/scipy-sphinx-theme
+
+      - run:
+          name: build docs
+          command: |
+            . venv/bin/activate
+            cd ~/repo
+            export SHELL=$(which bash)
+            python -u runtests.py -g --shell -- -c 'make -C doc PYTHON=python html-scipyorg'
+
+      - store_artifacts:
+          path: ~/repo/doc/build/html-scipyorg
+          destination: html-scipyorg
+
+workflows:
+  version: 2
+  default:
+    jobs:
+      - build_docs


### PR DESCRIPTION
`pip` install latest prerelease of SciPy (for speed, no need to build), then build latest docs.

Won't work until CircleCI is enabled for the repo.