### PR TITLE
[Discussion - multilingual feature] google_translate_element added in layout.html

### DIFF
--- a/_theme/scipy/layout.html
+++ b/_theme/scipy/layout.html
@@ -263,7 +263,21 @@
     {%- endif %}
     </ul>
     </div>
+
+    <!-- Google translator -->
+    <div class="row-fluid">
+      <div id="google_translate_element" style="text-align: center; padding-left: 30%; padding-right:40%; width:128px;"></div>
+
+        <script type="text/javascript">
+        function googleTranslateElementInit() {
+          new google.translate.TranslateElement({pageLanguage: 'en'}, 'google_translate_element');
+        }
+        </script>
+
+        <script type="text/javascript" src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+      </div>
     </div>
+
     </div>
 {%- endblock %}
   </body>


### PR DESCRIPTION
Google translator will help to translate in more than 100 languages. So now any scipy or numpy side which is using scipy-sphinx-theme will be having this feature at the footer. 

Here is a sample I tried with numpy.org repo :

<img width="1674" alt="Screen Shot 2019-08-28 at 4 06 17 PM" src="https://user-images.githubusercontent.com/5774448/63848626-d31e1500-c9ad-11e9-8152-24e4e52aa93a.png">
