### PR TITLE
Fix search issue in scipy devdocs.

### DIFF
--- a/_theme/scipy/layout.html
+++ b/_theme/scipy/layout.html
@@ -87,15 +87,7 @@
 {%- endmacro %}
 
 {%- macro script() %}
-    <script type="text/javascript">
-      var DOCUMENTATION_OPTIONS = {
-        URL_ROOT:    '{{ url_root }}',
-        VERSION:     '{{ release|e }}',
-        COLLAPSE_INDEX: false,
-        FILE_SUFFIX: '{{ '' if no_search_suffix else file_suffix }}',
-        HAS_SOURCE:  {{ has_source|lower }}
-      };
-    </script>
+    <script type="text/javascript" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
     {%- for scriptfile in script_files %}
     <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
     {%- endfor %}

--- a/_theme/scipy/layout.html
+++ b/_theme/scipy/layout.html
@@ -87,7 +87,7 @@
 {%- endmacro %}
 
 {%- macro script() %}
-    <script type="text/javascript" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
+    <script type="text/javascript" id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
     {%- for scriptfile in script_files %}
     <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
     {%- endfor %}


### PR DESCRIPTION
In https://scipy.github.io/devdocs, when you use the search box, the links it returns include an "undefined" that make them invalid.
Example: first link of https://scipy.github.io/devdocs/search.html?q=eigh is https://scipy.github.io/devdocs/generated/scipy.linalg.eighundefined?highlight=eigh.

This is because the LINK_SUFFIX is not assigned any value. The fix is to include the generated documentation_options.js file, so that irrespective of the Sphinx version, the appropriate attributes would be set.

For more details and the discussion, please check here: https://github.com/scipy/scipy/issues/11971